### PR TITLE
When the sensor is pulled out, it will stop.

### DIFF
--- a/src/AHT20.cpp
+++ b/src/AHT20.cpp
@@ -191,6 +191,12 @@ bool AHT20::available()
     }
 
     readData();
+    
+    if (sensorData.humidity < 0.1 && sensorData.temperature < -49)
+    {
+        return (false);
+    }
+
     measurementStarted = false;
     return (true);
 }


### PR DESCRIPTION
When the sensor was disconnected, the return value of avaiable was not returning false, but rather the temperature was being displayed as -50.0 and the humidity as 0.0. Therefore, I changed it so that false is returned when the temperature is -49 and humidity is less than 0.1.